### PR TITLE
Set precision to 4 for unit amount

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -454,7 +454,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
                 'name' => $item->getName(),
                 'description' => $item->getDescription(),
                 'totalAmount' => abs($item->getPrice()),
-                'unitAmount' => abs($unit_amount),
+                'unitAmount' => abs(number_format($unit_amount, 4)),
                 'kind' => $item_kind,
                 'quantity' => $item->getQuantity(),
             ));


### PR DESCRIPTION
To avoid rejected Braintree transactions, set unit amount to precision 4.