### PR TITLE
Change order of functions to avoid truncation of float

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -454,7 +454,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
                 'name' => $item->getName(),
                 'description' => $item->getDescription(),
                 'totalAmount' => abs($item->getPrice()),
-                'unitAmount' => abs(number_format($unit_amount, 4)),
+                'unitAmount' => number_format(abs($unit_amount), 4),
                 'kind' => $item_kind,
                 'quantity' => $item->getQuantity(),
             ));


### PR DESCRIPTION
It turns out that using `abs` on a float with a trailing `0` will cause the float to be truncated, resulting in a `Unit amount is an invalid format` as Braintree only accepts 2 or 4 for precision.